### PR TITLE
Update test setup to Julia 1.0

### DIFF
--- a/itf1788/plugins/julia/test/Base.Test/test.yaml
+++ b/itf1788/plugins/julia/test/Base.Test/test.yaml
@@ -21,7 +21,7 @@
 #   limitations under the License.
 
 imports: |
-    using Base.Test
+    using Test
 testfile_seq: |
     $COMMENTS
     $LANGUAGE_IMPORTS


### PR DESCRIPTION
`using Base.Test` was deprecated to -> `using Test` in Julia 1.0